### PR TITLE
make iterate() support arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ get the `type` tag at `start`
 
 an object containing the type tags.
 
+### iterate (buffer, start, fn) => void
+
+If the field at `start` is an object or array, then `iterate` will call the `fn`
+with arguments `fn(buffer, pointer, key)` for each subfield. If the field at
+`start` is not an array or object, this returns `-1`. You can stop/abort the
+iteration by making `fn` return any truthy value.
+
 ### seekKey (buffer, start, target) => pointer
 
 seek for a key `target` within an object. If

--- a/index.js
+++ b/index.js
@@ -272,7 +272,6 @@ function seekKey2 (buffer, start, target, t_start) {
   if(type != OBJECT) return -1
   for(; c + t_length < len;) {
     var b_tag = varint.decode(buffer, start+c)
-    
     if(b_tag === t_tag && buffer.compare(target, t_start, t_length, start+c, start+c+t_length) === 0)
       return start+c+(b_tag>>TAG_SIZE)+varint.decode.bytes
     else {
@@ -397,7 +396,7 @@ function iterate(buffer, start, iter) {
   var tag = varint.decode(buffer, start)
   var len = tag >> TAG_SIZE
   var type = tag & TAG_MASK
-  if(type == OBJECT) {
+  if(type === OBJECT) {
     for(var c = varint.decode.bytes; c < len;) {
       var key_start = start+c
       var key_tag = varint.decode(buffer, key_start)
@@ -409,19 +408,17 @@ function iterate(buffer, start, iter) {
       iter(buffer, value_start, key_start)
       c += next_start
     }
+    return start
   }
-  else if(type == ARRAY) {
+  else if(type === ARRAY) {
     var i = 0
     for(var c = varint.decode.bytes; c < len;) {
-      iter(buffer, start+c, i)
-      var key_tag = varint.decode(buffer, start+c)
-      c += varint.decode.bytes + (key_tag >> TAG_SIZE)
+      if (iter(buffer, start+c, i++)) return
       var value_tag = varint.decode(buffer, start+c)
       c += varint.decode.bytes + (value_tag >> TAG_SIZE)
     }
-  }
-
-  return -1
+    return start
+  } else return -1
 }
 
 function createCompareAt(paths) {

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ function read (key, b) {
       var l2 = b.readUInt16LE(c + l)>>3
       if(_key == key) //return b.toString('utf8', c, c+l2)
         return c+l //read_value(c-2, b)
-//      c += 
+//      c +=
       c+=l+2+l2+2
     }
   }
@@ -114,7 +114,7 @@ function traverse (buffer, start) {
 
 }
 
-tape('iterate', function (t) {
+tape('iterate object', function (t) {
   var pkg_buf = Buffer.alloc(binary.encodingLength(pkg))
   binary.encode(pkg, pkg_buf, 0)
 
@@ -127,5 +127,22 @@ tape('iterate', function (t) {
 
 })
 
+tape('iterate array', function (t) {
+  var myarr = ['cat', 'dog', 'bird', 'elephant'];
+  var myarr_buf = Buffer.alloc(binary.encodingLength(myarr));
+  binary.encode(myarr, myarr_buf, 0);
 
-
+  var expectedResults = [
+    [0, 2, 'cat'],
+    [1, 6, 'dog'],
+    [2, 10, 'bird'],
+    [3, 15, 'elephant'],
+  ];
+  binary.iterate(myarr_buf, 0, function (buffer, pointer, key) {
+    var expected = expectedResults.shift();
+    t.equal(key, expected[0], '' + expected[0]);
+    t.equal(pointer, expected[1], '' + expected[1]);
+    t.equal(binary.decode(buffer, pointer), expected[2], '' + expected[2]);
+  });
+  t.end();
+});


### PR DESCRIPTION
You can now do 

```js
bipf.iterate(buffer, pointerToArray, (buf, pointerToItem) => {
  console.log(bipf.decode(buffer, pointerToItem))
})
```

- fix implementation of iterate
- make iterate support aborting
- replace `==` with `===` (it's faster)
- added tests
- documented in readme