### PR TITLE
publish @staltz/bipf@1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bipf",
+  "name": "@staltz/bipf",
   "description": "binary in-place format",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/dominictarr/binary",
   "repository": {
     "type": "git",
@@ -12,6 +12,9 @@
   },
   "devDependencies": {
     "tape": "^4.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "test": "node test/index.js && node test/compare.js"


### PR DESCRIPTION
This is not a pull request, it's just a display of this branch `staltz-fork` to show the npm package `@staltz/bipf` as a temporary solution until we can publish `bipf` to npm.