### PR TITLE
Remove deprecated usages of Buffer constructor

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ test({})
 test([1,2,3,4,5,6,7,8,9])
 test('hello')
 test({foo: true})
-test([-1, {foo: true}, new Buffer('deadbeef', 'hex')])
+test([-1, {foo: true}, Buffer.from('deadbeef', 'hex')])
 test(pkg)
 
 

--- a/test/perf.js
+++ b/test/perf.js
@@ -12,7 +12,7 @@ var value = pkg
 var b = Buffer.alloc(binary.encodingLength(value))
 var start, json
 var json = JSON.stringify(value)
-var buffer = new Buffer(JSON.stringify(value))
+var buffer = Buffer.from(JSON.stringify(value))
 var N = 100000
 
 console.log('operation, ops/ms')
@@ -71,8 +71,8 @@ console.log('binary.seek2(encoded)', N/(Date.now() - start))
 // ---
 
 start = Date.now()
-var dependencies = new Buffer('dependencies')
-var varint = new Buffer('varint')
+var dependencies = Buffer.from('dependencies')
+var varint = Buffer.from('varint')
 for(var i = 0; i < N; i++) {
   var c, d
   binary.decode(b, d=binary.seekKey(b, c = binary.seekKey(b, 0, dependencies), varint))


### PR DESCRIPTION
`new Buffer(string, [encoding])` is deprecated in newer JS code & NodeJS, so this switches to use `Buffer.from` instead. This makes the tests less noisy.