### PR TITLE
Add compare value function

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,6 +355,20 @@ function compareString(buffer, start, target) {
   )
 }
 
+function compareValue(buffer, start, target) {
+  if (start === -1) return null
+  var tag = varint.decode(buffer, start)
+  var len = tag >> TAG_SIZE
+  var _len = Math.min(target.length, len)
+  return buffer.compare(
+    target,
+    0,
+    _len,
+    start + varint.decode.bytes,
+    start + varint.decode.bytes + _len
+  )
+}
+
 function isNull(tag) {
   return tag === 6
 }
@@ -472,6 +486,7 @@ module.exports = {
   seekKey2: seekKey2,
   createSeekPath: createSeekPath,
   seekPath: seekPath,
+  compareValue: compareValue,
   compareString: compareString,
   compare: compare,
   createCompareAt: createCompareAt,

--- a/test/compare.js
+++ b/test/compare.js
@@ -76,6 +76,25 @@ tape('compareString() with a buffer target', (t) => {
   t.end()
 })
 
+tape('compareValue() with a buffer target', (t) => {
+  const strBuf = bipf.allocAndEncode({ x: 'foo' })
+  const pointer = bipf.seekKey(strBuf, 0, Buffer.from('x'))
+  const eq = bipf.compareValue(strBuf, pointer, Buffer.from('foo'))
+  const lt = bipf.compareValue(strBuf, pointer, Buffer.from('abc'))
+  const gt = bipf.compareValue(strBuf, pointer, Buffer.from('good'))
+  t.equals(eq, 0)
+  t.equals(lt, 1)
+  t.equals(gt, -1)
+  t.end()
+})
+
+tape('compareValue() with a negative start', (t) => {
+  const strBuf = bipf.allocAndEncode('foo')
+  const result = bipf.compareValue(strBuf, -1, Buffer.from('foo'))
+  t.equals(result, null)
+  t.end()
+})
+
 tape('compare() can sort with null undefined too', (t) => {
   const values = [
     null,


### PR DESCRIPTION
This function is similar to `compareString` but instead works on any type. It simply compares the actual encoded buffer to check if they are equal ignoring the type.