### PR TITLE
add new API seekKeyCached()

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ see performance section for discussion on the performance
 of seek - if it's only needed to parse a couple of elements,
 it can be significantly faster than parsing.
 
+### seekKeyCached (buffer, start, target) => pointer
+
+Same as `seekKey`, but uses a cache to avoid re-seeking the pointers if the
+same arguments have been provided in the past.
+
 ### seekPath (buffer, start, array_of_buffers) => pointer
 
 The same as `seekKey`, except for a recursive path.

--- a/index.js
+++ b/index.js
@@ -268,6 +268,30 @@ function seekKey(buffer, start, target) {
   return -1
 }
 
+//         buffer ->   start ->        target -> result
+// WeakMap<Buffer, Map<number, WeakMap<Buffer, number>>>
+const cache1 = new WeakMap()
+
+function seekKeyCached(buffer, start, target) {
+  let cache2 = cache1.get(buffer)
+  if (!cache2) {
+    cache2 = new Map()
+    cache1.set(buffer, cache2)
+  }
+  let cache3 = cache2.get(start)
+  if (!cache3) {
+    cache3 = new WeakMap()
+    cache2.set(start, cache3)
+  }
+  if (cache3.has(target)) {
+    return cache3.get(target)
+  } else {
+    const result = seekKey(buffer, start, target)
+    cache3.set(target, result)
+    return result
+  }
+}
+
 function seekKey2(buffer, start, target, t_start) {
   var tag = varint.decode(buffer, start)
   var type = tag & TAG_MASK
@@ -469,6 +493,7 @@ module.exports = {
   getEncodedLength: getEncodedLength,
   getEncodedType: getEncodedType,
   seekKey: seekKey,
+  seekKeyCached: seekKeyCached,
   seekKey2: seekKey2,
   createSeekPath: createSeekPath,
   seekPath: seekPath,

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
-    "tap-spec": "^5.0.0",
+    "tap-arc": "~0.3.4",
     "tape": "^5.3.1"
   },
   "scripts": {
-    "test": "tape test/index.js | tap-spec && tape test/compare.js | tap-spec",
+    "test": "tape test/index.js | tap-arc && tape test/compare.js | tap-arc",
     "coverage": "nyc --reporter=lcov npm test",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",

--- a/test/index.js
+++ b/test/index.js
@@ -158,6 +158,15 @@ tape('seekKey() on an object', (t) => {
   t.end()
 })
 
+tape('seekKeyCached() on an object', (t) => {
+  const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
+  const pointer = bipf.seekKeyCached(objEncoded, 0, Buffer.from('y', 'utf-8'))
+  t.equals(pointer, 10)
+  const twenty = bipf.decode(objEncoded, pointer)
+  t.equals(twenty, 20)
+  t.end()
+})
+
 tape('seekKey() with a negative start on an object', (t) => {
   const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
   const pointer = bipf.seekKey(objEncoded, -1, Buffer.from('y', 'utf-8'))

--- a/test/perf.js
+++ b/test/perf.js
@@ -48,8 +48,9 @@ function buildStructure(level) {
 faker.seed(348230432)
 console.log('Generating JSON structure...')
 const genDate = new Date()
-var pkg = buildStructure(0)
+var fakeData = buildStructure(0)
 console.log('Structure generated in ' + (new Date() - genDate) + 'ms')
+const pkg = require('../package.json')
 
 function encode(string) {
   var b = Buffer.alloc(BIPF.encodingLength(string))
@@ -57,25 +58,24 @@ function encode(string) {
   return b
 }
 
-var value = pkg
-var b = Buffer.alloc(BIPF.encodingLength(value))
+var b = Buffer.alloc(BIPF.encodingLength(fakeData))
 var start, json
-var json = JSON.stringify(value)
-var buffer = Buffer.from(JSON.stringify(value))
+var json = JSON.stringify(fakeData)
+var buffer = Buffer.from(JSON.stringify(fakeData))
 var N = 10000
 
 console.log('operation, ops/ms')
 start = Date.now()
 for (var i = 0; i < N; i++) {
   //not an honest test
-  b = Buffer.allocUnsafe(BIPF.encodingLength(value))
-  BIPF.encode(value, b, 0)
+  b = Buffer.allocUnsafe(BIPF.encodingLength(fakeData))
+  BIPF.encode(fakeData, b, 0)
 }
 console.log('BIPF.encode', N / (Date.now() - start))
 // ---
 start = Date.now()
 for (var i = 0; i < N; i++) {
-  JSON.stringify(value)
+  JSON.stringify(fakeData)
 }
 console.log('JSON.stringify', N / (Date.now() - start))
 // ---
@@ -102,6 +102,9 @@ for (var i = 0; i < N; i++) {
   JSON.stringify(JSON.parse(json))
 }
 console.log('JSON.stringify(JSON.parse())', N / (Date.now() - start))
+
+var b = Buffer.alloc(BIPF.encodingLength(pkg))
+BIPF.encode(pkg, b, 0)
 
 // ---
 start = Date.now()

--- a/test/perf.js
+++ b/test/perf.js
@@ -139,6 +139,23 @@ console.log('BIPF.seek(buffer)', N / (Date.now() - start))
 // ---
 
 start = Date.now()
+var dependencies = Buffer.from('dependencies')
+var varint = Buffer.from('varint')
+for (var i = 0; i < N; i++) {
+  var c, d
+  BIPF.decode(
+    b,
+    (d = BIPF.seekKeyCached(
+      b,
+      (c = BIPF.seekKeyCached(b, 0, dependencies)),
+      varint
+    ))
+  )
+}
+console.log('BIPF.seekCached(buffer)', N / (Date.now() - start))
+// ---
+
+start = Date.now()
 var path = encode(['dependencies', 'varint'])
 for (var i = 0; i < N; i++) {
   var c, d


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/ssb-db2/pull/324

`seekKey` is very often used, so we may be doing redundant computations. `seekKeyCached` uses WeakMaps and Maps as caches for the arguments with the results.

The use of WeakMap means that as soon as the `buffer` argument is deallocated by GC, the cache will be deallocated as well.

Benchmark results:

```
Generating JSON structure...
Structure generated in 25ms
operation, ops/ms
BIPF.encode 1.7966223499820337
JSON.stringify 4.462293618920125
BIPF.decode 7.2727272727272725
JSON.parse 5.878894767783657
JSON.parse(buffer) 5.698005698005698
JSON.stringify(JSON.parse()) 3.020235578375113
BIPF.seek(string) 416.6666666666667
BIPF.seek2(encoded) 666.6666666666666
BIPF.seek(buffer) 1000
BIPF.seekCached(buffer) 2000
BIPF.seekPath(encoded) 625
BIPF.seekPath(compiled) 909.0909090909091
BIPF.compare() 370.3703703703704
```