### PR TITLE
seekKeyCached supports only string target arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ it can be significantly faster than parsing.
 ### seekKeyCached (buffer, start, target) => pointer
 
 Same as `seekKey`, but uses a cache to avoid re-seeking the pointers if the
-same arguments have been provided in the past.
+same arguments have been provided in the past. However, `target` must be a
+string, not a buffer.
 
 ### seekPath (buffer, start, array_of_buffers) => pointer
 

--- a/index.js
+++ b/index.js
@@ -268,8 +268,8 @@ function seekKey(buffer, start, target) {
   return -1
 }
 
-//         buffer ->   start ->        target -> result
-// WeakMap<Buffer, Map<number, WeakMap<Buffer, number>>>
+//         buffer ->   start ->    target -> result
+// WeakMap<Buffer, Map<number, Map<string, number>>>
 const cache1 = new WeakMap()
 
 function seekKeyCached(buffer, start, target) {
@@ -280,8 +280,11 @@ function seekKeyCached(buffer, start, target) {
   }
   let cache3 = cache2.get(start)
   if (!cache3) {
-    cache3 = new WeakMap()
+    cache3 = new Map()
     cache2.set(start, cache3)
+  }
+  if (Buffer.isBuffer(target)) {
+    throw new Error('seekKeyCached only supports string target, not buffer')
   }
   if (cache3.has(target)) {
     return cache3.get(target)

--- a/index.js
+++ b/index.js
@@ -274,14 +274,11 @@ const cache1 = new WeakMap()
 
 function seekKeyCached(buffer, start, target) {
   let cache2 = cache1.get(buffer)
-  if (!cache2) {
-    cache2 = new Map()
-    cache1.set(buffer, cache2)
-  }
+  if (!cache2) cache1.set(buffer, cache2 = new Map())
   let cache3 = cache2.get(start)
-  if (!cache3) {
-    cache3 = new Map()
-    cache2.set(start, cache3)
+  if (!cache3) cache2.set(start, cache3 = new Map())
+  if (typeof target !== 'string') {
+    throw new Error('seekKeyCached only supports string target')
   }
   if (Buffer.isBuffer(target)) {
     throw new Error('seekKeyCached only supports string target, not buffer')

--- a/index.js
+++ b/index.js
@@ -274,9 +274,9 @@ const cache1 = new WeakMap()
 
 function seekKeyCached(buffer, start, target) {
   let cache2 = cache1.get(buffer)
-  if (!cache2) cache1.set(buffer, cache2 = new Map())
+  if (!cache2) cache1.set(buffer, (cache2 = new Map()))
   let cache3 = cache2.get(start)
-  if (!cache3) cache2.set(start, cache3 = new Map())
+  if (!cache3) cache2.set(start, (cache3 = new Map()))
   if (typeof target !== 'string') {
     throw new Error('seekKeyCached only supports string target')
   }

--- a/index.js
+++ b/index.js
@@ -280,9 +280,6 @@ function seekKeyCached(buffer, start, target) {
   if (typeof target !== 'string') {
     throw new Error('seekKeyCached only supports string target')
   }
-  if (Buffer.isBuffer(target)) {
-    throw new Error('seekKeyCached only supports string target, not buffer')
-  }
   if (cache3.has(target)) {
     return cache3.get(target)
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -162,7 +162,7 @@ tape('seekKeyCached() on an object with buffer target', (t) => {
   const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
   t.throws(() => {
     bipf.seekKeyCached(objEncoded, 0, Buffer.from('y', 'utf-8'))
-  }, /not buffer/)
+  }, /seekKeyCached only supports string target/)
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -158,9 +158,17 @@ tape('seekKey() on an object', (t) => {
   t.end()
 })
 
-tape('seekKeyCached() on an object', (t) => {
+tape('seekKeyCached() on an object with buffer target', (t) => {
   const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
-  const pointer = bipf.seekKeyCached(objEncoded, 0, Buffer.from('y', 'utf-8'))
+  t.throws(() => {
+    bipf.seekKeyCached(objEncoded, 0, Buffer.from('y', 'utf-8'))
+  }, /not buffer/)
+  t.end()
+})
+
+tape('seekKeyCached() on an object with string target', (t) => {
+  const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
+  const pointer = bipf.seekKeyCached(objEncoded, 0, 'y')
   t.equals(pointer, 10)
   const twenty = bipf.decode(objEncoded, pointer)
   t.equals(twenty, 20)

--- a/test/perf.js
+++ b/test/perf.js
@@ -139,16 +139,14 @@ console.log('BIPF.seek(buffer)', N / (Date.now() - start))
 // ---
 
 start = Date.now()
-var dependencies = Buffer.from('dependencies')
-var varint = Buffer.from('varint')
 for (var i = 0; i < N; i++) {
   var c, d
   BIPF.decode(
     b,
     (d = BIPF.seekKeyCached(
       b,
-      (c = BIPF.seekKeyCached(b, 0, dependencies)),
-      varint
+      (c = BIPF.seekKeyCached(b, 0, 'dependencies')),
+      'varint'
     ))
   )
 }


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/jitdb/pull/209#issuecomment-1087482324

I opted to remove support for **buffer** `target` and keep only **string** `target` because:

- We can't have strings as keys in `WeakMap` (because strings don't get deallocated)
- We shouldn't have buffers as keys in `Map` (because it would retain these buffers from being GCd)
- The string `target` is anyway converted only once when `seekKeyCached` calls `seekKey`

For the record, perf bench:

```
Generating JSON structure...
Structure generated in 26ms
operation, ops/ms
BIPF.encode 1.9179133103183736
JSON.stringify 4.557885141294439
BIPF.decode 7.1022727272727275
JSON.parse 5.408328826392645
JSON.parse(buffer) 5.537098560354374
JSON.stringify(JSON.parse()) 3.114294612270321
BIPF.seek(string) 285.7142857142857
BIPF.seek2(encoded) 555.5555555555555
BIPF.seek(buffer) 909.0909090909091
BIPF.seekCached(buffer) 1428.5714285714287
BIPF.seekPath(encoded) 500
BIPF.seekPath(compiled) 666.6666666666666
BIPF.compare() 344.82758620689657
```