### PR TITLE
improve performance of encode()

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,8 +157,7 @@ function getType(value) {
 
 function encodingLength(value) {
   var type = getType(value)
-  if ('function' !== typeof encodingLengthers[type])
-    throw new Error('unknown type:' + type + ', ' + JSON.stringify(value))
+  if (type === void 0) throw new Error('unknown type: ' + JSON.stringify(value))
   var len = encodingLengthers[type](value)
   return varint.encodingLength(len << TAG_SIZE) + len
 }

--- a/index.js
+++ b/index.js
@@ -183,8 +183,7 @@ function getEncodedType(buffer, start) {
 function encode(value, buffer, start, _len) {
   start = start | 0
   var type = getType(value)
-  if ('function' !== typeof encodingLengthers[type])
-    throw new Error('unknown type:' + type + ', ' + JSON.stringify(value))
+  if (type === void 0) throw new Error('unknown type: ' + JSON.stringify(value))
   var len = _len === undefined ? encodingLengthers[type](value) : _len
   //  if(!buffer)
   //    buffer = Buffer.allocUnsafe(len)


### PR DESCRIPTION
## Context

I was running the Chrome profiler for Node.js and found a nice heatmap on BIPF's index.js. I am trying to optimize seekKeyCached (i'll get to that soon), but I also stumbled upon a couple other easy wins.

## Problem

The `typeof encodingLengthers[type] !== 'function'` isn't that cheap to run, see the before and after heatmaps. (Take a close look at the left-side measurements on the `if` condition) There's 74.8ms versus 6.5ms.

## Solution

`getType` always returns the numbers we want, it doesn't return unexpected numbers, it will just return undefined when the type is invalid, so we can just directly check for `type === undefined`. And since it's possible to use `undefined` as a var name, it's safer to compare with `void 0` (a synonym for undefined).


## Before

![Screenshot from 2022-04-06 11-36-17](https://user-images.githubusercontent.com/90512/161934255-faa08271-3c24-48e7-b97a-0f6f6709139a.png)


```
operation, ops/ms
BIPF.encode 1.9179133103183736
JSON.stringify 4.557885141294439
BIPF.decode 7.1022727272727275
JSON.parse 5.408328826392645
JSON.parse(buffer) 5.537098560354374
JSON.stringify(JSON.parse()) 3.114294612270321
BIPF.seek(string) 285.7142857142857
BIPF.seek2(encoded) 555.5555555555555
BIPF.seek(buffer) 909.0909090909091
BIPF.seekCached(buffer) 1428.5714285714287
BIPF.seekPath(encoded) 500
BIPF.seekPath(compiled) 666.6666666666666
BIPF.compare() 344.82758620689657
```


## After 

![Screenshot from 2022-04-06 11-39-06](https://user-images.githubusercontent.com/90512/161934319-74d226d1-6d02-469c-8f26-8d0b89311c14.png)


```
operation, ops/ms
BIPF.encode 1.9105846388995031
JSON.stringify 4.739336492890995
BIPF.decode 7.710100231303007
JSON.parse 6.079027355623101
JSON.parse(buffer) 5
JSON.stringify(JSON.parse()) 2.6874496103198067
BIPF.seek(string) 303.030303030303
BIPF.seek2(encoded) 500
BIPF.seek(buffer) 666.6666666666666
BIPF.seekCached(buffer) 1250
BIPF.seekPath(encoded) 434.7826086956522
BIPF.seekPath(compiled) 555.5555555555555
BIPF.compare() 285.7142857142857
BIPF.seek(uniqueMsg) 769.2307692307693
BIPF.seekCached(uniqueMsg) 1000
```