### PR TITLE
Improve seekKey2

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ see performance section for discussion on the performance
 of seek - if it's only needed to parse a couple of elements,
 it can be significantly faster than parsing.
 
+### seekKey2 (buffer, start, target, target_start) => pointer
+
+Same as `seekKey`, except `target` must be an encoded value. This is
+usually done using `allocAndEncode`. This is a bit faster.
+
 ### seekKeyCached (buffer, start, target) => pointer
 
 Same as `seekKey`, but uses a cache to avoid re-seeking the pointers if the

--- a/index.js
+++ b/index.js
@@ -295,10 +295,11 @@ function seekKey2(buffer, start, target, t_start) {
   var len = tag >> TAG_SIZE
   var t_tag = varint.decode(target, t_start)
   var t_length = (t_tag >> TAG_SIZE) + varint.decode.bytes
-  for (; c + t_length < len; ) {
-    var b_tag = varint.decode(buffer, start + c)
+  for (; c < len; ) {
+    var key_tag = varint.decode(buffer, start + c)
+
     if (
-      b_tag === t_tag &&
+      key_tag === t_tag &&
       buffer.compare(
         target,
         t_start,
@@ -307,11 +308,16 @@ function seekKey2(buffer, start, target, t_start) {
         start + c + t_length
       ) === 0
     )
-      return start + c + (b_tag >> TAG_SIZE) + varint.decode.bytes
-    else {
-      c += (b_tag >> TAG_SIZE) + varint.decode.bytes //key
-      c += (varint.decode(buffer, start + c) >> TAG_SIZE) + varint.decode.bytes //value
-    }
+      return start + c + t_length
+
+    c += varint.decode.bytes
+    var key_len = key_tag >> TAG_SIZE
+    c += key_len
+
+    var value_tag = varint.decode(buffer, start + c)
+    c += varint.decode.bytes
+    var value_len = value_tag >> TAG_SIZE
+    c += value_len
   }
   return -1
 }

--- a/test/index.js
+++ b/test/index.js
@@ -158,6 +158,16 @@ tape('seekKey() on an object', (t) => {
   t.end()
 })
 
+tape('seekKey2() on an object', (t) => {
+  const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
+  const key = bipf.allocAndEncode('y')
+  const pointer = bipf.seekKey2(objEncoded, 0, key, 0)
+  t.equals(pointer, 10)
+  const twenty = bipf.decode(objEncoded, pointer)
+  t.equals(twenty, 20)
+  t.end()
+})
+
 tape('seekKeyCached() on an object with buffer target', (t) => {
   const objEncoded = bipf.allocAndEncode({ x: 10, y: 20 })
   t.throws(() => {

--- a/test/perf.js
+++ b/test/perf.js
@@ -124,6 +124,16 @@ for (var i = 0; i < N; i++) {
 }
 console.log('BIPF.seek(string)', N / (Date.now() - start))
 
+// ---
+
+start = Date.now()
+var dependencies = Buffer.from('dependencies')
+var varint = Buffer.from('varint')
+for (var i = 0; i < N; i++) {
+  BIPF.decode(b, BIPF.seekKey(b, BIPF.seekKey(b, 0, dependencies), varint))
+}
+console.log('BIPF.seek(buffer)', N / (Date.now() - start))
+
 var _varint = encode('varint'),
   _dependencies = encode('dependencies')
 start = Date.now()
@@ -134,19 +144,15 @@ for (var i = 0; i < N; i++) {
   )
 }
 console.log('BIPF.seek2(encoded)', N / (Date.now() - start))
-// ---
 
 start = Date.now()
-var dependencies = Buffer.from('dependencies')
-var varint = Buffer.from('varint')
 for (var i = 0; i < N; i++) {
-  var c, d
   BIPF.decode(
     b,
-    (d = BIPF.seekKey(b, (c = BIPF.seekKey(b, 0, dependencies)), varint))
+    BIPF.seekKey2(b, BIPF.seekKey2(b, 0, _dependencies, 0), _varint, 0)
   )
 }
-console.log('BIPF.seek(buffer)', N / (Date.now() - start))
+console.log('BIPF.seek2(encoded) second run', N / (Date.now() - start))
 // ---
 
 start = Date.now()


### PR DESCRIPTION
I was looking at `seekKey2` to see what it actually does. It seems to be a performance improvement compared to `seekKey` by taking in an encoded target. Similar to seekKey being faster on buffers directly. I improved the performance test a bit because the second time you run a function v8 has optimized it a bit. So the previous comparison was a bit unfair. Not super happy about the name, changing that would be a breaking change.

Anyway performance gains are real in real world tests as well. I ported over jitdb to use this function and my normal db2 performance test improved from roughly 10.5 seconds to 10 seconds.