### PR TITLE
Use faster varint decode by default

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -1,4 +1,7 @@
-const varint = require('varint')
+const varint =
+  typeof BIPF_LARGE_VARINT !== 'undefined'
+    ? require('varint')
+    : require('./varint-small-decode')
 const { INT, DOUBLE, STRING, TAG_SIZE, TAG_MASK } = require('./constants')
 const { createSeekPath } = require('./seekers')
 

--- a/decode.js
+++ b/decode.js
@@ -1,4 +1,7 @@
-const varint = require('varint')
+const varint =
+  typeof BIPF_LARGE_VARINT !== 'undefined'
+    ? require('varint')
+    : require('./varint-small-decode')
 const { TAG_SIZE, TAG_MASK } = require('./constants')
 const {
   STRING,

--- a/encode.js
+++ b/encode.js
@@ -1,4 +1,7 @@
-const varint = require('varint')
+const varint =
+  typeof BIPF_LARGE_VARINT !== 'undefined'
+    ? require('varint')
+    : require('./varint-small-decode')
 const { TAG_SIZE, TAG_MASK } = require('./constants')
 const {
   STRING,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-const varint = require('varint')
+const varint =
+  typeof BIPF_LARGE_VARINT !== 'undefined'
+    ? require('varint')
+    : require('./varint-small-decode')
 
 const { types, TAG_SIZE, TAG_MASK, OBJECT, ARRAY } = require('./constants')
 const { decode } = require('./decode')

--- a/large-varint.js
+++ b/large-varint.js
@@ -1,0 +1,2 @@
+BIPF_LARGE_VARINT = 1
+return require('./')

--- a/seekers.js
+++ b/seekers.js
@@ -1,4 +1,7 @@
-const varint = require('varint')
+const varint =
+  typeof BIPF_LARGE_VARINT !== 'undefined'
+    ? require('varint')
+    : require('./varint-small-decode')
 const { decode } = require('./decode')
 const { STRING, OBJECT, TAG_SIZE, TAG_MASK } = require('./constants')
 

--- a/varint-small-decode.js
+++ b/varint-small-decode.js
@@ -1,0 +1,40 @@
+// this function is based on the varint library
+//
+// It is modified here to only work on smaller numbers (2^27).
+// In BIPF this function is a hot-path, so we want it to be as
+// fast as humanly possible. vardim is used to encode the tag
+// (type + length) and most lengths are small. If your system
+// (such as messages in SSB) are capped, then this is no problem.
+//
+// 27 bits (3 for type) still leaves 24 bits for a max length of
+// 16777216.
+//
+// this function is up to 10x faster than decode in varint
+
+const MSB = 0x80
+const REST = 0x7f
+
+module.exports = require('varint')
+module.exports.decode = function read(buf, offset) {
+  offset = offset || 0
+  let res = 0,
+    shift = 0,
+    counter = offset,
+    b
+
+  do {
+    b = buf[counter++]
+
+    if (b === undefined || shift >= 28) {
+      read.bytes = 0
+      throw new RangeError('Could not decode varint')
+    }
+
+    res += (b & REST) << shift
+    shift += 7
+  } while (b >= MSB)
+
+  read.bytes = counter - offset
+
+  return res
+}


### PR DESCRIPTION
I was going over the different issues in this repo and cleaning things up. One thing that has been on the back of my mind is https://github.com/ssbc/bipf/issues/21. Which links to a [decode optimization](https://github.com/chrisdickinson/varint/pull/24) in varint. I tried putting that code in my "empty database, query for 1 author" and was surprised  that it was slower. I went looking a bit deeper and this leb128 compression is also used in protobuf, where the c++ implementation of this is unrolled. So you really know that it's a hot path in that case :)

I was wondering if we could simplify the varint implementation. The way we use varints in this module is for tag, so type + length of the fields. At least in the case of SSB there is a hard limit on the message size, so we know for sure that nothing is bigger than a few kb. In that case we can use a special version of varint that only works on smaller numbers (2^24) and remove some of the branching.

I made the changes to the file inside the varint module, modified the tests to only pass in smaller numbers and all the tests pass and the decode function is close to 10x faster.

In my testing the same  "empty database, query for 1 author" goes from around 34.4 sec to 30.0 sec. So a substantial reduction.

Very interested to hear what @Barbarrosa says to this :-)

In this PR I have enabled the optimization by default, so this could be seen as a breaking change. I'm also a bit certain if there is a better way. I thought we should at least support the old behavior as well. I'm leaving this PR as draft because of this last point. It is ready otherwise.