### PR TITLE
Use fast-varint instead of varint

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -1,4 +1,4 @@
-const varint = require('varint')
+const varint = require('fast-varint')
 const { INT, DOUBLE, STRING, TAG_SIZE, TAG_MASK } = require('./constants')
 const { createSeekPath } = require('./seekers')
 

--- a/decode.js
+++ b/decode.js
@@ -1,4 +1,4 @@
-const varint = require('varint')
+const varint = require('fast-varint')
 const { TAG_SIZE, TAG_MASK } = require('./constants')
 const {
   STRING,

--- a/encode.js
+++ b/encode.js
@@ -1,4 +1,4 @@
-const varint = require('varint')
+const varint = require('fast-varint')
 const { TAG_SIZE, TAG_MASK } = require('./constants')
 const {
   STRING,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const varint = require('varint')
+const varint = require('fast-varint')
 
 const { types, TAG_SIZE, TAG_MASK, OBJECT, ARRAY } = require('./constants')
 const { decode } = require('./decode')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/ssbc/bipf.git"
   },
   "dependencies": {
-    "varint": "^5.0.0"
+    "fast-varint": "^1.0.0"
   },
   "devDependencies": {
     "faker": "^5.5.1",

--- a/seekers.js
+++ b/seekers.js
@@ -1,4 +1,4 @@
-const varint = require('varint')
+const varint = require('fast-varint')
 const { decode } = require('./decode')
 const { STRING, OBJECT, TAG_SIZE, TAG_MASK } = require('./constants')
 


### PR DESCRIPTION
So I forked varint to https://github.com/arj03/fast-varint. Implemented the unrolled version of the code in https://www.dolthub.com/blog/2021-01-08-optimizing-varint-decoding/. Javascript is a bit different, but I could keep the same fast version for the smaller numbers (int32 roughly) so we get the same speedup as https://github.com/ssbc/bipf/pull/36. The good thing about this is that we now know all the ordinary test still passes :)