### PR TITLE
refactor: keep module.exports consistent

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -65,37 +65,39 @@ function compare(buffer1, start1, buffer2, start2) {
   )
 }
 
-module.exports = {
-  compareString(buffer, start, target) {
-    if (start === -1) return null
-    target = Buffer.isBuffer(target) ? target : Buffer.from(target)
-    const tag = varint.decode(buffer, start)
-    if ((tag & TAG_MASK) !== STRING) return null
-    const len = tag >> TAG_SIZE
-    const _len = Math.min(target.length, len)
-    return (
-      buffer.compare(
-        target,
-        0,
-        _len,
-        start + varint.decode.bytes,
-        start + varint.decode.bytes + _len
-      ) || target.length - len
-    )
-  },
+function compareString(buffer, start, target) {
+  if (start === -1) return null
+  target = Buffer.isBuffer(target) ? target : Buffer.from(target)
+  const tag = varint.decode(buffer, start)
+  if ((tag & TAG_MASK) !== STRING) return null
+  const len = tag >> TAG_SIZE
+  const _len = Math.min(target.length, len)
+  return (
+    buffer.compare(
+      target,
+      0,
+      _len,
+      start + varint.decode.bytes,
+      start + varint.decode.bytes + _len
+    ) || target.length - len
+  )
+}
 
-  compare,
-
-  createCompareAt(paths) {
-    const getPaths = paths.map(createSeekPath)
-    return function (a, b) {
-      for (let i = 0; i < getPaths.length; i++) {
-        const _a = getPaths[i](a, 0)
-        const _b = getPaths[i](b, 0)
-        const r = compare(a, _a, b, _b)
-        if (r) return r
-      }
-      return 0
+function createCompareAt(paths) {
+  const getPaths = paths.map(createSeekPath)
+  return function (a, b) {
+    for (let i = 0; i < getPaths.length; i++) {
+      const _a = getPaths[i](a, 0)
+      const _b = getPaths[i](b, 0)
+      const r = compare(a, _a, b, _b)
+      if (r) return r
     }
-  },
+    return 0
+  }
+}
+
+module.exports = {
+  compareString,
+  compare,
+  createCompareAt,
 }

--- a/encode.js
+++ b/encode.js
@@ -109,25 +109,26 @@ function encode(value, buffer, start, _len) {
   return encoders[type](value, buffer, start + bytes) + bytes
 }
 
+function getEncodedLength(buffer, start) {
+  return varint.decode(buffer, start) >> TAG_SIZE
+}
+
+function getEncodedType(buffer, start) {
+  return varint.decode(buffer, start) & TAG_MASK
+}
+
+function allocAndEncode(value) {
+  const len = encodingLength(value)
+  const buffer = Buffer.allocUnsafe(len)
+  encode(value, buffer, 0)
+  return buffer
+}
+
 module.exports = {
   encode,
-
   getType,
-
-  getEncodedLength(buffer, start) {
-    return varint.decode(buffer, start) >> TAG_SIZE
-  },
-
-  getEncodedType(buffer, start) {
-    return varint.decode(buffer, start) & TAG_MASK
-  },
-
+  getEncodedLength,
+  getEncodedType,
   encodingLength,
-
-  allocAndEncode(value) {
-    const len = encodingLength(value)
-    const buffer = Buffer.allocUnsafe(len)
-    encode(value, buffer, 0)
-    return buffer
-  },
+  allocAndEncode,
 }


### PR DESCRIPTION
Just a refactor that shuffles things around. I noticed that the `module.exports = {` section of a file sometimes had the implementation of a function, sometimes did not. I moved them up such that the `module.exports` section is boring and all the implementation is in the file.