### PR TITLE
add encodeIdempotent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,50 @@ implementations throw an error.
 write `value` to `buffer` from start.  returns the number of bytes
 used.
 
+### allocAndEncode(value) => buffer
+
+allocate a new buffer and write `value` into it.  returns the newly
+created buffer.
+
+### encodeIdempotent(value, buffer, start) => length
+
+same as `encode`, but *tags* the buffer as being a `bipf` buffer, such
+that you can place this buffer in another encoded bipf, and it won't
+be "double encoded", it will just be embedded inside the larger buffer.
+
+### allocAndEncodeIdempotent(value) => buffer
+
+same as `allocAndEncode`, but *tags* the resulting buffer as being a
+`bipf` buffer.
+
+Example:
+
+```js
+var obj = {address: {street: '123 Main St'}}
+var buf1 = bipf.allocAndEncode(obj)
+
+var innerObj = {street: '123 Main St'}
+var innerBuf = bipf.allocAndEncodeIdempotent(innerObj)
+var outerObj = {address: innerBuf}
+var buf2 = bipf.allocAndEncode(outerObj)
+
+deepEquals(buf1, buf2) // true
+```
+
+Counter-example:
+
+```js
+var obj = {address: {street: '123 Main St'}}
+var buf1 = bipf.allocAndEncode(obj)
+
+var innerObj = {street: '123 Main St'}
+var innerBuf = bipf.allocAndEncode(innerObj)
+var outerObj = {address: innerBuf}
+var buf2 = bipf.allocAndEncode(outerObj)
+
+deepEquals(buf1, buf2) // false
+```
+
 ### decode(buffer, start) => value
 
 read the next value from `buffer` at `start`.  returns the value, and

--- a/constants.js
+++ b/constants.js
@@ -10,6 +10,8 @@ const OBJECT = 5 // 101
 const BOOLNULL = 6 // 110 // and use the rest of the byte as true/false/null
 const RESERVED = 7 // 111
 
+const ALREADY_BIPF = 8
+
 const TAG_SIZE = 3
 const TAG_MASK = 7
 
@@ -22,6 +24,8 @@ module.exports = {
   OBJECT,
   BOOLNULL,
   RESERVED,
+
+  ALREADY_BIPF,
 
   TAG_SIZE,
   TAG_MASK,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,24 @@
 const varint = require('fast-varint')
 
-const { types, TAG_SIZE, TAG_MASK, OBJECT, ARRAY } = require('./constants')
+const {
+  types,
+  TAG_SIZE,
+  TAG_MASK,
+  STRING,
+  BUFFER,
+  INT,
+  DOUBLE,
+  OBJECT,
+  ARRAY,
+  BOOLNULL,
+} = require('./constants')
 const { decode } = require('./decode')
 const {
   encode,
+  encodeIdempotent,
   encodingLength,
   allocAndEncode,
+  allocAndEncodeIdempotent,
   getEncodedLength,
   getEncodedType,
   getType,
@@ -58,8 +71,10 @@ function iterate(buffer, start, iter) {
 
 module.exports = {
   encode,
+  encodeIdempotent,
   decode,
   allocAndEncode,
+  allocAndEncodeIdempotent,
   encodingLength,
   buffer: true,
   slice,

--- a/test/index.js
+++ b/test/index.js
@@ -207,6 +207,14 @@ tape('slice() on an object field', (t) => {
   t.end()
 })
 
+tape('encodeIdempotent()', (t) => {
+  const buf1 = bipf.allocAndEncode({ address: { street: '123 Main St' } })
+  const streetBipf = bipf.allocAndEncodeIdempotent({ street: '123 Main St' })
+  const buf2 = bipf.allocAndEncode({ address: streetBipf })
+  t.deepEquals(buf1, buf2)
+  t.end()
+})
+
 tape('iterate() over an encoded object', (t) => {
   const obj = { x: 10, y: 'foo', z: { age: 80 } }
   const objBuf = bipf.allocAndEncode(obj)


### PR DESCRIPTION
**Context:** we're working on adding [buttwoo](https://github.com/ssbc/ssb-buttwoo-spec/) support in ssb-db2, and since buttwoo is based in bipf, there is a use case for taking the bipf-encoded buttwoo message and wrapping it with "key" and "timestamp" to make up a KVT. Thus the "V" is already bipf-encoded and we don't want to double encode it (as a buffer type).

**Problem:** there is no API in BIPF at the moment that easily allows doing this, instead, we rely on manually using varint [like this](https://github.com/ssbc/ssb-buttwoo/blob/ff43a4e808daffde04c5a97b3531534094eba879/index.js#L189-L190), which sounds like it should be a `bipf` low-level concern, not buttwoo.

**Solution:** new API `encodeIdempotent()` and `allocAndEncodeIdempotent()`. 

**Example:**

```js
const buf1 = bipf.allocAndEncode({ address: { street: '123 Main St' } })
const streetBipf = bipf.allocAndEncodeIdempotent({ street: '123 Main St' })
const buf2 = bipf.allocAndEncode({ address: streetBipf })
deepEquals(buf1, buf2)
```