### PR TITLE
add pluck() API, similar to slice()

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ implementations throw an error.
 `encode, decode, encodingLength` follow the interface specified by
 [`abstract-encoding`](https://github.com/mafintosh/abstract-encoding)
 
+### encodingLength(value) => length
+
+returns the length needed to encode `value`
+
 ### encode(value, buffer, start) => length
 
 write `value` to `buffer` from start.  returns the number of bytes
@@ -192,9 +196,10 @@ deepEquals(buf1, buf2) // false
 read the next value from `buffer` at `start`.  returns the value, and
 sets `decode.bytes` to number of bytes used.
 
-### encodingLength(value) => length
+### pluck(buffer, start) => buffer
 
-returns the length needed to encode `value`
+reads the value from BIPF-encoded `buffer` at `start`, and returns the
+*encoded* value at that pointer, without decoding it.
 
 ### getValueType(value) => type
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@ function slice(buffer, start) {
   )
 }
 
+function pluck(buffer, start) {
+  const tagValue = varint.decode(buffer, start)
+  const length = tagValue >> TAG_SIZE
+  return buffer.slice(start, start + varint.decode.bytes + length)
+}
+
 function iterate(buffer, start, iter) {
   const tag = varint.decode(buffer, start)
   const len = tag >> TAG_SIZE
@@ -78,6 +84,7 @@ module.exports = {
   encodingLength,
   buffer: true,
   slice,
+  pluck,
   getValueType: getType,
   getEncodedLength,
   getEncodedType,

--- a/test/index.js
+++ b/test/index.js
@@ -207,6 +207,15 @@ tape('slice() on an object field', (t) => {
   t.end()
 })
 
+tape('pluck() on an object', (t) => {
+  const ageEncoded = bipf.allocAndEncode({ age: 3 })
+  const objEncoded = bipf.allocAndEncode({ x: 'foo', y: { age: 3 } })
+  const pointer = bipf.seekKey(objEncoded, 0, Buffer.from('y', 'utf-8'))
+  const plucked = bipf.pluck(objEncoded, pointer)
+  t.deepEquals(plucked, ageEncoded)
+  t.end()
+})
+
 tape('encodeIdempotent()', (t) => {
   const buf1 = bipf.allocAndEncode({ address: { street: '123 Main St' } })
   const streetBipf = bipf.allocAndEncodeIdempotent({ street: '123 Main St' })


### PR DESCRIPTION
`slice()` is kind of weird, I don't understand its use case. Maybe it's wrong? Anyway, I didn't want to create a breaking change now, we can do that later. Instead, what I did was introduce a new API: `pluck()`

Very similar to slice, the difference is that `pluck()` always returns a BIPF-encoded buffer, i.e. retains the `tag`. Slice returns the decoded bipf, but still as a buffer (so weird!).

This is going to be useful in the ssb-db2 refactor when manipulating raw BIPF. E.g. pluck `value` from `KVT.value` when `KVT` is in BIPF.