### PR TITLE
add isIdempotent() and markIdempotent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ var buf2 = bipf.allocAndEncode(outerObj)
 deepEquals(buf1, buf2) // false
 ```
 
+### markIdempotent(buffer) => buffer
+
+does nothing else but *tag* the buffer as being a `bipf` buffer, such
+that you can place it in another encoded bipf, and it won't be "double
+encoded", it will just be embedded inside the larger buffer.
+
+returns the same buffer as the input.
+
+### isIdempotent(buffer) => boolean
+
+returns true if `buffer` received an `encodeIdempotent()` call or a
+`markIdempotent()` call.
+
 ### decode(buffer, start) => value
 
 read the next value from `buffer` at `start`.  returns the value, and

--- a/encode.js
+++ b/encode.js
@@ -124,6 +124,15 @@ function encodeIdempotent(value, buffer, start) {
   return buffer
 }
 
+function markIdempotent(buffer) {
+  buffer._IS_BIPF_ENCODED = true
+  return buffer
+}
+
+function isIdempotent(buffer) {
+  return !!buffer._IS_BIPF_ENCODED
+}
+
 function getEncodedLength(buffer, start) {
   return varint.decode(buffer, start) >> TAG_SIZE
 }
@@ -149,6 +158,8 @@ function allocAndEncodeIdempotent(value) {
 module.exports = {
   encode,
   encodeIdempotent,
+  markIdempotent,
+  isIdempotent,
   getType,
   getEncodedLength,
   getEncodedType,

--- a/encode.js
+++ b/encode.js
@@ -119,9 +119,9 @@ function encode(value, buffer, start, _len) {
 }
 
 function encodeIdempotent(value, buffer, start) {
-  encode(value, buffer, start)
+  const len = encode(value, buffer, start)
   buffer._IS_BIPF_ENCODED = true
-  return buffer
+  return len
 }
 
 function markIdempotent(buffer) {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const { decode } = require('./decode')
 const {
   encode,
   encodeIdempotent,
+  markIdempotent,
+  isIdempotent,
   encodingLength,
   allocAndEncode,
   allocAndEncodeIdempotent,
@@ -78,6 +80,8 @@ function iterate(buffer, start, iter) {
 module.exports = {
   encode,
   encodeIdempotent,
+  markIdempotent,
+  isIdempotent,
   decode,
   allocAndEncode,
   allocAndEncodeIdempotent,

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,18 @@ tape('pluck() on an object', (t) => {
 tape('encodeIdempotent()', (t) => {
   const buf1 = bipf.allocAndEncode({ address: { street: '123 Main St' } })
   const streetBipf = bipf.allocAndEncodeIdempotent({ street: '123 Main St' })
+  t.true(bipf.isIdempotent(streetBipf))
+  const buf2 = bipf.allocAndEncode({ address: streetBipf })
+  t.deepEquals(buf1, buf2)
+  t.end()
+})
+
+tape('tagIdempotent()', (t) => {
+  const buf1 = bipf.allocAndEncode({ address: { street: '123 Main St' } })
+  const streetBipf = bipf.markIdempotent(
+    bipf.allocAndEncode({ street: '123 Main St' })
+  )
+  t.true(bipf.isIdempotent(streetBipf))
   const buf2 = bipf.allocAndEncode({ address: streetBipf })
   t.deepEquals(buf1, buf2)
   t.end()


### PR DESCRIPTION
We shouldn't use `_IS_BIPF_ENCODED`, that's an internal implementation detail. Instead, here's `isIdempotent()`, and another nice util `markIdempotent()` which takes a ready-encoded bipf buffer and tags it.

I also fixed the return value of `encodeIdempotent()`. It was wrong (compare e.g. with what the readme promised), it should return a length just like `encode()` returns.